### PR TITLE
experimental: version bump

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -3,5 +3,5 @@ name: core
 description: A helm chart to deploy Calyptia Inc. core on Kubernetes
 
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: v1.1.2


### PR DESCRIPTION
```
Run helm/chart-releaser-action@v1.5.0
  with:
    version: v1.5.0
    charts_dir: charts
  env:
    CR_TOKEN: ***
Run owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
Looking up latest tag...
Discovering changed charts since 'core-1.1.0'...
Installing chart-releaser on /opt/hostedtoolcache/cr/v1.5.0/x86_64...
Adding cr directory to PATH...
Packaging chart 'charts/core'...
Successfully packaged chart in /home/runner/work/charts/charts/charts/core and saved it to: .cr-release-packages/core-1.1.0.tgz
Releasing charts...
Error: error creating GitHub release core-1.1.0: POST https://api.github.com/repos/calyptia/charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
Usage:
  cr upload [flags]
```
 We are getting the above error and I am going to try a fix suggested in a Gh [issue](https://github.com/helm/chart-releaser-action/issues/30#issuecomment-679974056)