### PR TITLE
minor: add automation for version

### DIFF
--- a/.github/scripts/semverCheck.sh
+++ b/.github/scripts/semverCheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eEu
+if [[ "$NEW_CALYPTIA_CORE_VERSION" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]] ; then
+    NEW_CALYPTIA_CORE_VERSION=${BASH_REMATCH[1]}
+    echo "Valid version string: $NEW_CALYPTIA_CORE_VERSION"
+else
+    echo "ERROR: Invalid semver string: $NEW_CALYPTIA_CORE_VERSION"
+    exit 1
+fi

--- a/.github/workflows/cron-sync-core.yaml
+++ b/.github/workflows/cron-sync-core.yaml
@@ -27,15 +27,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_PAT }}
 
-      - run: source .github/scripts/semverCheck.sh
-        env:
-          NEW_CALYPTIA_CORE_VERSION: ${{ steps.get-core-release.outputs.tag }}
-        shell: bash
-
       # Note we assume a simple version update so no chart version update
-      - run: |
+      - name: Run the sed on the chart file
+        run: |
+          if [[ "$NEW_CALYPTIA_CORE_VERSION" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]] ; then
+              NEW_CALYPTIA_CORE_VERSION=${BASH_REMATCH[1]}
+              echo "Valid version string: $NEW_CALYPTIA_CORE_VERSION"
+          else
+              echo "ERROR: Invalid semver string: $NEW_CALYPTIA_CORE_VERSION"
+              exit 1
+          fi
           sed -i "s/^version.*$/version: $NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
           sed -i "s/^appVersion.*$/appVersion: v$NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
+          echo "chart version=$NEW_CALYPTIA_CORE_VERSION" >> $GITHUB_OUTPUT
+          echo "app version=v$NEW_CALYPTIA_CORE_VERSION" >> $GITHUB_OUTPUT
         env:
           NEW_CALYPTIA_CORE_VERSION: ${{ steps.get-core-release.outputs.tag }}
         shell: bash

--- a/.github/workflows/cron-sync-core.yaml
+++ b/.github/workflows/cron-sync-core.yaml
@@ -27,11 +27,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_PAT }}
 
+      - run: source .github/scripts/semverCheck.sh
+        env:
+          NEW_CALYPTIA_CORE_VERSION: ${{ steps.get-core-release.outputs.tag }}
+        shell: bash
+
       # Note we assume a simple version update so no chart version update
       - run: |
-          sed -i "s/^appVersion.*$/appVersion: $NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
-          NEW_CALYPTIA_CORE_VERSION_="${NEW_CALYPTIA_CORE_VERSION:1}"
-          sed -i "s/^version.*$/version: $NEW_CALYPTIA_CORE_VERSION_/g" ./charts/core/Chart.yaml
+          sed -i "s/^version.*$/version: $NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
+          sed -i "s/^appVersion.*$/appVersion: v$NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
         env:
           NEW_CALYPTIA_CORE_VERSION: ${{ steps.get-core-release.outputs.tag }}
         shell: bash

--- a/.github/workflows/cron-sync-core.yaml
+++ b/.github/workflows/cron-sync-core.yaml
@@ -30,6 +30,8 @@ jobs:
       # Note we assume a simple version update so no chart version update
       - run: |
           sed -i "s/^appVersion.*$/appVersion: $NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
+          NEW_CALYPTIA_CORE_VERSION_="${NEW_CALYPTIA_CORE_VERSION:1}"
+          sed -i "s/^version.*$/version: $NEW_CALYPTIA_CORE_VERSION_/g" ./charts/core/Chart.yaml
         env:
           NEW_CALYPTIA_CORE_VERSION: ${{ steps.get-core-release.outputs.tag }}
         shell: bash


### PR DESCRIPTION
PR for issue: https://github.com/calyptia/charts/issues/41
The helm chart releaser checks version number in Helm Chart's Chart.yaml.
The workflow only replaced the [appVersion](https://github.com/calyptia/charts/blob/master/.github/workflows/cron-sync-core.yaml#L32) number from the latest tag from calyptia/core repo
Just added a sed command