### PR TITLE
aws: add support for Calyptia integration

### DIFF
--- a/charts/aws-fluent-bit/Chart.yaml
+++ b/charts/aws-fluent-bit/Chart.yaml
@@ -3,9 +3,9 @@ apiVersion: v2
 name: fluent-bit-helm
 description: Fast and lightweight observability processor and forwarder for Linux, Windows and macOS
 home: https://calyptia.com/products/lts-fluentbit/
-icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
+icon: https://storage.googleapis.com/calyptia_public_resources_bucket/logo-darkmode.svg
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: "v22.10.5"
 maintainers:
   - name: Calyptia

--- a/charts/aws-fluent-bit/README.md
+++ b/charts/aws-fluent-bit/README.md
@@ -1,6 +1,8 @@
 # AWS Marketplace Calyptia Fluent Bit
 
-A helm chart intended to be used with the [AWS marketplace version of Calyptia Fluent Bit](https://aws.amazon.com/marketplace/pp/prodview-z2en74bwhkfug).
+A Helm chart intended to be used with the [AWS marketplace version of Calyptia Fluent Bit](https://aws.amazon.com/marketplace/pp/prodview-z2en74bwhkfug).
+
+This requires an EKS cluster set up with a service account using the `arn:aws:iam::aws:policy/AWSMarketplaceMeteringRegisterUsage` policy.
 
 ## Usage
 
@@ -10,21 +12,22 @@ Ensure a service account is set up with the `arn:aws:iam::aws:policy/AWSMarketpl
 eksctl create cluster --name <clustername> --version 1.2x --region <region-code>
 ```
 
-By default, EKS has an OpenID Connect(OIDC) issuer URL to provide federated access. AWS IAM supports IDP's that are compatible with OpenIDConnect to establish trust relationships to access the AWS account.
-
+By default, EKS has an OpenID Connect(OIDC) issuer URL to provide federated access.
+AWS IAM supports IDP's that are compatible with OpenIDConnect to establish trust relationships to access the AWS account.
 
 ### Adding the [IdP](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) with the AWS IAM service
 
-```
+```shell
 eksctl utils associate-iam-oidc-provider --cluster=<clusterName> --approve
 ```
 
-You could check if the IdP has been added by going to the AWS IAM console in Identity providers under Access management
+You can check if the IdP has been added by going to the AWS IAM console in Identity providers under Access management.
 
 ### Creating the IAM role and the Kubernetes Service Account
-The below command will create the role and the kubernetes service account in the respective namespace. 
 
-```
+The below command will create the role and the kubernetes service account in the respective namespace.
+
+```shell
 eksctl create iamserviceaccount \
  --name sa-calyptia-fluentbit \
  --namespace calyptia-fluentbit \
@@ -35,13 +38,10 @@ eksctl create iamserviceaccount \
  --override-existing-serviceaccounts
 ```
 
-verify if the trust relationship is configured correctly by running the below command:
-```
-aws iam get-role --role-name <enterthenameoftherole> --query Role.AssumeRolePolicyDocument
-```
+Verify if the trust relationship is configured correctly by running the below command:
 
-Expected Output:
-```
+```shell
+$ aws iam get-role --role-name <enterthenameoftherole> --query Role.AssumeRolePolicyDocument
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -63,24 +63,24 @@ Expected Output:
 ```
 
 verify that you attached to your role is attached as expected:
-```
-aws iam list-attached-role-policies --role-name aws-marketplace-access-role --output text
-```
 
-Expected Output:
-```
+```shell
+$ aws iam list-attached-role-policies --role-name aws-marketplace-access-role --output text
+...
 ATTACHEDPOLICIES        arn:aws:iam::aws:policy/AWSMarketplaceMeteringRegisterUsage     AWSMarketplaceMeteringRegisterUsage
+...
 ```
-
 
 confirm if the kubernetes service account that got created is annotated with the role:
-```
+
+```shell
 kubectl describe serviceaccount <enterthenameoftheserviceaccount> -n calyptia-fluentbit
 ```
 
+### Helm chart install
 
-[Helm](https://helm.sh) must be installed to use the charts.  Please refer to
-Helm's [documentation](https://helm.sh/docs) to get started.
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs) to get started.
 
 Once Helm has been set up correctly, add the repo as follows:
 
@@ -88,9 +88,8 @@ Once Helm has been set up correctly, add the repo as follows:
 helm repo add calyptia https://helm.calyptia.com
 ```
 
-If you had already added this repo earlier, run `helm repo update` to retrieve
-the latest versions of the packages.  You can then run `helm search repo
-<alias>` to see the charts.
+If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions of the packages.
+You can then run `helm search repo <alias>` to see the charts.
 
 To install the calyptia-fluentbit chart:
 

--- a/charts/aws-fluent-bit/templates/NOTES.txt
+++ b/charts/aws-fluent-bit/templates/NOTES.txt
@@ -6,3 +6,9 @@ To learn more about the release, try:
 
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}
+
+Get Calyptia Fluent Bit information by running these commands:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "calyptia-fluent-bit.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 2020:2020
+curl http://127.0.0.1:2020 

--- a/charts/aws-fluent-bit/templates/clusterrole.yaml
+++ b/charts/aws-fluent-bit/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,3 +19,24 @@ rules:
       - get
       - list
       - watch
+  {{- if and .Values.podSecurityPolicy.create (semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion) }}
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ include "calyptia-fluent-bit.fullname" . }}
+    verbs:
+      - use
+  {{- end }}
+  {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - {{ include "calyptia-fluent-bit.fullname" . }}
+    verbs:
+      - use
+  {{- end }}
+{{- end -}}

--- a/charts/aws-fluent-bit/templates/clusterrole.yaml
+++ b/charts/aws-fluent-bit/templates/clusterrole.yaml
@@ -19,16 +19,6 @@ rules:
       - get
       - list
       - watch
-  {{- if and .Values.podSecurityPolicy.create (semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion) }}
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
-    resourceNames:
-      - {{ include "calyptia-fluent-bit.fullname" . }}
-    verbs:
-      - use
-  {{- end }}
   {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
   - apiGroups:
       - security.openshift.io

--- a/charts/aws-fluent-bit/templates/configmap-luascripts.yaml
+++ b/charts/aws-fluent-bit/templates/configmap-luascripts.yaml
@@ -1,0 +1,12 @@
+{{- if gt (len .Values.luaScripts) 0 -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "calyptia-fluent-bit.fullname" . }}-luascripts
+  labels:
+    {{- include "calyptia-fluent-bit.labels" . | nindent 4 }}
+data:
+  {{ range $key, $value := .Values.luaScripts }}
+  {{ $key }}: {{ $value | quote }}
+  {{ end }}
+{{- end -}}

--- a/charts/aws-fluent-bit/templates/configmap.yaml
+++ b/charts/aws-fluent-bit/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
     {{- (tpl .Values.config.inputs $)  | nindent 4 }}
     {{- (tpl .Values.config.filters $)  | nindent 4 }}
     {{- (tpl .Values.config.outputs $)  | nindent 4 }}
+  {{- if .Values.project_token -}}
+    {{- (tpl .Values.config.calyptia $)  | nindent 4 }}
+  {{- end -}}
   {{- range $key, $val := .Values.config.upstream }}
   {{ $key }}: |
     {{- (tpl $val $) | nindent 4 }}

--- a/charts/aws-fluent-bit/templates/daemonset.yaml
+++ b/charts/aws-fluent-bit/templates/daemonset.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ default "fluentbit" .Values.namespace.name }}
+  namespace: {{ default "calyptia-fluentbit" .Values.namespace.name }}
 spec:
   selector:
     matchLabels:
@@ -20,6 +20,9 @@ spec:
 
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-fluent-bit/templates/scc.yaml
+++ b/charts/aws-fluent-bit/templates/scc.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "calyptia-fluent-bit.fullname" . }}
+{{- if .Values.openShift.securityContextConstraints.annotations }}
+  annotations:
+    {{- toYaml .Values.openShift.securityContextConstraints.annotations | nindent 4 }}
+{{- end }}
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostDirVolumePlugin: true
+defaultAllowPrivilegeEscalation: false
+# forbid host namespaces
+allowHostNetwork: false
+allowHostIPC: false
+allowHostPorts: false
+allowHostPID: false
+allowedCapabilities: []
+forbiddenSysctls:
+- "*"
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - secret
+{{- end }}

--- a/charts/aws-fluent-bit/values.yaml
+++ b/charts/aws-fluent-bit/values.yaml
@@ -1,3 +1,11 @@
+calyptia:
+  ## Calyptia Project Token to use: see https://core.calyptia.com
+  project_token: ""
+  api_url: "https://cloud-api.calyptia.com/"
+  port: 443
+  tls: "on"
+  tls_verify: "on"
+
 namespace:
 ## Namespace creation is set to false as the namespace is expected to be created through the CLI since eksctl command may require.
   create: false
@@ -59,47 +67,65 @@ luaScripts: {}
 config:
   service: |
     [SERVICE]
-        Daemon Off
-        Flush {{ .Values.flush }}
-        Log_Level {{ .Values.logLevel }}
-        Parsers_File parsers.conf
-        Parsers_File custom_parsers.conf
-        HTTP_Server On
-        HTTP_Listen 0.0.0.0
-        HTTP_Port {{ .Values.metricsPort }}
-        Health_Check On
+        Daemon              Off
+        Flush               {{ .Values.flush }}
+        Log_Level           {{ .Values.logLevel }}
+        Parsers_File        parsers.conf
+        Parsers_File        custom_parsers.conf
+        HTTP_Server         On
+        HTTP_Listen         0.0.0.0
+        HTTP_Port           {{ .Values.metricsPort }}
+        Health_Check        On
+        storage.metrics     On
 
   ## https://docs.fluentbit.io/manual/pipeline/inputs
   inputs: |
     [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        multiline.parser docker, cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
+        Name                tail
+        Path                /var/log/containers/*.log
+        multiline.parser    docker, cri
+        Tag                 kube.*
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
 
     [INPUT]
-        Name systemd
-        Tag host.*
-        Systemd_Filter _SYSTEMD_UNIT=kubelet.service
-        Read_From_Tail On
+        Name                systemd
+        Tag                 host.*
+        Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
+        Read_From_Tail      On
+    
+    [INPUT]
+        name                fluentbit_metrics
+        tag                 metrics.calyptia
+        scrape_on_start     true
+        scrape_interval     30
 
   ## https://docs.fluentbit.io/manual/pipeline/filters
   filters: |
     [FILTER]
-        Name kubernetes
-        Match kube.*
-        Merge_Log On
-        Keep_Log Off
-        K8S-Logging.Parser On
+        Name                kubernetes
+        Match               kube.*
+        Merge_Log           On
+        Keep_Log            Off
+        K8S-Logging.Parser  On
         K8S-Logging.Exclude On
 
   ## https://docs.fluentbit.io/manual/pipeline/outputs
   outputs: |
     [OUTPUT]
-        Name stdout
-        Match *
+        Name                stdout
+        Match               *
+
+  ## Only included if we have a project token
+  calyptia: |
+    [OUTPUT]
+        Name                calyptia
+        Match               *
+        api_key             {{ required "A valid Calyptia project_token is required." .Values.calyptia.project_token }}
+        calyptia_host       {{ .Values.calyptia.api_url }}
+        calyptia_port       {{ .Values.calyptia.port }}
+        calyptia_tls        {{ .Values.calyptia.tls }}
+        calyptia_tls.verify {{ .Values.calyptia.tls_verify }}
 
   ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/upstream-servers
   ## This configuration is deprecated, please use `extraFiles` instead.
@@ -108,11 +134,11 @@ config:
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
     [PARSER]
-        Name docker_no_time
-        Format json
-        Time_Keep Off
-        Time_Key time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Name                docker_no_time
+        Format              json
+        Time_Keep           Off
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%L
 
   extraFiles: {}
 
@@ -150,3 +176,11 @@ daemonSetVolumeMounts:
 
 flush: 1
 logLevel: info
+
+openShift:
+  # Sets Openshift support
+  enabled: false
+  # Creates SCC for when Openshift support is enabled
+  securityContextConstraints:
+    create: true
+    annotations: {}

--- a/charts/aws-fluent-bit/values.yaml
+++ b/charts/aws-fluent-bit/values.yaml
@@ -184,3 +184,12 @@ openShift:
   securityContextConstraints:
     create: true
     annotations: {}
+
+# Configure podsecuritypolicy
+# Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+# from Kubernetes 1.25, PSP is deprecated
+# See: https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes
+# We automatically disable PSP if Kubernetes version is 1.25 or higher
+podSecurityPolicy:
+  create: false
+  annotations: {}

--- a/charts/aws-fluent-bit/values.yaml
+++ b/charts/aws-fluent-bit/values.yaml
@@ -184,12 +184,3 @@ openShift:
   securityContextConstraints:
     create: true
     annotations: {}
-
-# Configure podsecuritypolicy
-# Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
-# from Kubernetes 1.25, PSP is deprecated
-# See: https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes
-# We automatically disable PSP if Kubernetes version is 1.25 or higher
-podSecurityPolicy:
-  create: false
-  annotations: {}

--- a/charts/aws-fluent-bit/values.yaml
+++ b/charts/aws-fluent-bit/values.yaml
@@ -93,7 +93,7 @@ config:
         Tag                 host.*
         Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
         Read_From_Tail      On
-    
+
     [INPUT]
         name                fluentbit_metrics
         tag                 metrics.calyptia

--- a/charts/aws-fluent-bit/values.yaml
+++ b/charts/aws-fluent-bit/values.yaml
@@ -41,11 +41,13 @@ readinessProbe:
     path: /api/v1/health
     port: http
 extraVolumes: []
+
+## Ensure any UID matching is set up to allow access to files on the host
 securityContext: {}
+
 extraVolumeMounts: []
 
 existingConfigMap: ""
-
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Integrate directly with Calyptia Core for upcoming Fleet management.

Addresses #47.