### PR TITLE
ci: fix core chart app versioning

### DIFF
--- a/.github/workflows/cron-sync-core.yaml
+++ b/.github/workflows/cron-sync-core.yaml
@@ -38,9 +38,9 @@ jobs:
               exit 1
           fi
           sed -i "s/^version.*$/version: $NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
-          sed -i "s/^appVersion.*$/appVersion: v$NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
+          sed -i "s/^appVersion.*$/appVersion: $NEW_CALYPTIA_CORE_VERSION/g" ./charts/core/Chart.yaml
           echo "chart version=$NEW_CALYPTIA_CORE_VERSION" >> $GITHUB_OUTPUT
-          echo "app version=v$NEW_CALYPTIA_CORE_VERSION" >> $GITHUB_OUTPUT
+          echo "app version=$NEW_CALYPTIA_CORE_VERSION" >> $GITHUB_OUTPUT
         env:
           NEW_CALYPTIA_CORE_VERSION: ${{ steps.get-core-release.outputs.tag }}
         shell: bash


### PR DESCRIPTION
removes v from app version

https://calyptia.slack.com/archives/C04V45036SE/p1690184055764979

Assuming we don't want v based on [this](https://github.com/calyptia/core/blob/b0182ec46019494451ffe3decc80d6da01c1f863/.github/workflows/ci.yml#L143) comment. Removed v from app version