### PR TITLE
ci: Upgrade remaining GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
       - name: Add dependency charts
         run: |
           helm repo add fluent https://fluent.github.io/helm-charts --force-update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,8 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
-
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Add dependency charts
         run: |
           helm repo add fluent https://fluent.github.io/helm-charts --force-update

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
       - name: Add dependency charts
         run: |
           helm repo add fluent https://fluent.github.io/helm-charts --force-update

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
-
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Add dependency charts
         run: |
           helm repo add fluent https://fluent.github.io/helm-charts --force-update


### PR DESCRIPTION
## Summary
- Upgrades remaining JS-based GitHub Actions from Node 20 to Node 22+ versions (second wave)
- SHA-pins all upgraded action references for supply-chain security
- Covers docker/*, google-github-actions/*, aws-actions/*, azure/*, goreleaser/*, helm/kind-action, crazy-max/ghaction-import-gpg, and first-wave stragglers missed by a regex bug
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)